### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/SevenSegShift/keywords.txt
+++ b/SevenSegShift/keywords.txt
@@ -5,14 +5,14 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-SevenSeg KEYWORD1
-Color KEYWORD1
+SevenSeg	KEYWORD1
+Color	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-setNumber KEYWORD2
-clear KEYWORD2
+setNumber	KEYWORD2
+clear	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords